### PR TITLE
Broader compatibility by not requiring all values

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,113 @@
+.git
+.gitignore
+README.md
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# pyenv
+.python-version
+
+# celery beat schedule file
+celerybeat-schedule
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+
+# pycharm
+.idea/
+
+# personal
+build*

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,107 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# pyenv
+.python-version
+
+# celery beat schedule file
+celerybeat-schedule
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+
+# pycharm
+.idea/

--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@ These are all the available environment variables, along with some example value
 | INFLUXDB_USER | myuser | optional, defaults to empty |
 | INFLUXDB_PASSWORD | pass | optional, defaults to empty |
 | INFLUXDB_PORT |  8086 | optional, defaults to 8086 |
-| VERBOSE | true | if anything but true docker logging will show no output
+| INTERVAL | 5 | optional, defaults to 5 seconds |
+| VERBOSE | true | if anything but true docker logging will show no output |
 
 ## How to Use
 
@@ -51,6 +52,7 @@ services:
       APCUPSD_HOST: 10.0.1.11
       INFLUXDB_HOST: 10.0.1.11
       HOSTNAME: unraid
+      INTERVAL: 5
 ```
 
 If you want to debug the apcaccess output or the send to influxdb, set the environment variable "VERBOSE" to "true"

--- a/apcupsd-influxdb-exporter.py
+++ b/apcupsd-influxdb-exporter.py
@@ -5,12 +5,13 @@ import time
 from apcaccess import status as apc
 from influxdb import InfluxDBClient
 
-hostname = os.getenv('HOSTNAME', 'apcupsd-influxdb-exporter')
+
 dbname = os.getenv('INFLUXDB_DATABASE', 'apcupsd')
 user = os.getenv('INFLUXDB_USER')
 password = os.getenv('INFLUXDB_PASSWORD')
 port = os.getenv('INFLUXDB_PORT', 8086)
 host = os.getenv('INFLUXDB_HOST', 'localhost')
+interval = float(os.getenv('INTERVAL', 5))
 client = InfluxDBClient(host, port, user, password, dbname)
 
 client.create_database(dbname)
@@ -18,27 +19,26 @@ client.create_database(dbname)
 while True:
     ups = apc.parse(apc.get(host=os.getenv('APCUPSD_HOST', 'localhost')), strip_units=True)
 
-    if os.environ['WATTS']:
-        ups['NOMPOWER'] = os.getenv('WATTS')
-
-    watts = float(ups['NOMPOWER']) * 0.01 * float(ups['LOADPCT'])
+    watts = float(os.getenv('WATTS', ups.get('NOMPOWER', 0.0))) * 0.01 * float(ups.get('LOADPCT', 0.0))
     json_body = [
         {
             'measurement': 'apcaccess_status',
             'fields': {
                 'WATTS': watts,
-                'LOADPCT': float(ups['LOADPCT']),
-                'BCHARGE': float(ups['BCHARGE']),
-                'TONBATT': float(ups['TONBATT']),
-                'TIMELEFT': float(ups['TIMELEFT']),
-                'NOMPOWER': float(ups['NOMPOWER']),
-                'CUMONBATT': float(ups['CUMONBATT']),
-                'BATTV': float(ups['BATTV']),
-                'OUTPUTV': float(ups['OUTPUTV']),
-                'ITEMP': float(ups['ITEMP'])
+                'STATUS': ups.get('STATUS'),
+                'LOADPCT': float(ups.get('LOADPCT', 0.0)),
+                'BCHARGE': float(ups.get('BCHARGE', 0.0)),
+                'TONBATT': float(ups.get('TONBATT', 0.0)),
+                'TIMELEFT': float(ups.get('TIMELEFT', 0.0)),
+                'NOMPOWER': float(ups.get('NOMPOWER', 0.0)),
+                'CUMONBATT': float(ups.get('CUMONBATT', 0.0)),
+                'BATTV': float(ups.get('BATTV', 0.0)),
+                'OUTPUTV': float(ups.get('OUTPUTV', 0.0)),
+                'ITEMP': float(ups.get('ITEMP', 0.0)),
             },
             'tags': {
-                'host': hostname
+                'host': os.getenv('HOSTNAME', ups.get('HOSTNAME', 'apcupsd-influxdb-exporter')),
+                'serial': ups.get('SERIALNO', None),
             }
         }
     ]
@@ -48,4 +48,4 @@ while True:
         print(client.write_points(json_body))
     else:
         client.write_points(json_body)
-    time.sleep(5)
+    time.sleep(interval)


### PR DESCRIPTION
I changed all the ups[] to ups.get() commands with a default 0.0. I also added adjustable interval and a serial tag.

This should fix a lot of the compatibility issues other people are seeing.