### PR TITLE
Reconnect to InfluxDB on connection error

### DIFF
--- a/apcupsd-influxdb-exporter.py
+++ b/apcupsd-influxdb-exporter.py
@@ -1,5 +1,6 @@
 #!/usr/bin/python
 import os
+import requests.exceptions
 import time
 
 from apcaccess import status as apc


### PR DESCRIPTION
This clears the InfluxDB client object, and reconnects to InfluxDB on connection error.

Also, the sleep in the loop has been moved outside of the try/except block, to avoid using 100% CPU if there are exceptions in the try block.