### PR TITLE
added ALARMDEL to remove_these_keys

### DIFF
--- a/apcupsd-influxdb-exporter.py
+++ b/apcupsd-influxdb-exporter.py
@@ -35,7 +35,7 @@ delay = min_delay
 
 print_to_console = os.getenv('VERBOSE', 'false').lower() == 'true'
 
-remove_these_keys = ['DATE', 'STARTTIME', 'END APC']
+remove_these_keys = ['DATE', 'STARTTIME', 'END APC','ALARMDEL']
 tag_keys = ['APC', 'HOSTNAME', 'UPSNAME', 'VERSION', 'CABLE', 'MODEL', 'UPSMODE', 'DRIVER', 'APCMODEL']
 
 watts_key = 'WATTS'


### PR DESCRIPTION
The ALARMDEL field type is something that will change when a user turns the UPS alarm either on or off. 

If the alarm is on, the default value is 30s. If the user then experiences a power outage and turns the alarm off during the outage, InfluxDB will reject the field because it has been changed to a string. 

Error: 
```
400: {"error":"partial write: field type conflict: input field \"ALARMDEL\" on measurement \"apcaccess_status\" is type string, already exists as type float dropped=1"}
```

I thought about having an if rule in convert_numerical_values_to_floats() that passes the specific field or always converts it to a string, but that will break 50% of existing databases, so I think this is the best fix. 

Besides I don't think it's used much on different dashboards, but I may be wrong.